### PR TITLE
Enhanced Share Result with Social Share Modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@
     <div class="actions" id="actions">
       <button class="action-btn" onclick="generateTombstone()">🪦 Mint Tombstone</button>
       <button class="action-btn pill-btn hidden" id="copiumBtn" onclick="takeCopium()">💊 Delulu Pill</button>
+      <button class="action-btn" onclick="openShareModal()">📤 Share Result</button>
     </div>
 
   </div> </div> <div id="deluluModal" class="modal-overlay hidden" onclick="handleOverlayClick(event,'deluluModal')">
@@ -161,6 +162,22 @@
 </div>
 
 <canvas id="tombstoneCanvas" width="400" height="500" style="display:none;"></canvas>
+<!-- SHARE MODAL -->
+<div id="shareModal" class="modal-overlay hidden" onclick="handleOverlayClick(event,'shareModal')">
+  <div class="modal-box">
+    <button class="modal-close" onclick="closeModal('shareModal')">✕</button>
+    <span class="modal-icon">📤</span>
+    <h2 class="modal-title">Share Your Result</h2>
+
+    <div style="display:flex; gap:12px; flex-wrap:wrap; justify-content:center; margin-top:20px;">
+      <button class="modal-btn" onclick="shareWhatsApp()">WhatsApp</button>
+      <button class="modal-btn" onclick="shareTwitter()">X</button>
+      <button class="modal-btn" onclick="shareFacebook()">Facebook</button>
+      <button class="modal-btn" onclick="shareInstagram()">Instagram</button>
+      <button class="modal-btn secondary" onclick="copyShareText()">Copy</button>
+    </div>
+  </div>
+</div>
 
 <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -305,3 +305,45 @@ function closeModal(id) {
 function handleOverlayClick(e, id) {
   if (e.target.id === id) closeModal(id);
 }
+// ============ SHARE SYSTEM ============
+
+function getShareText() {
+  const siteURL = "https://uttarapraveen.github.io/How-Cooked-Are-You-/";
+
+  return `I'm ${currentCookedLevel}% cooked 🔥💀
+
+Patient: ${studentNameGlobal}
+
+Try yours here:
+${siteURL}`;
+}
+
+function openShareModal() {
+  document.getElementById("shareModal").classList.remove("hidden");
+}
+
+function shareWhatsApp() {
+  const text = encodeURIComponent(getShareText());
+  window.open(`https://wa.me/?text=${text}`, "_blank");
+}
+
+function shareTwitter() {
+  const text = encodeURIComponent(getShareText());
+  window.open(`https://twitter.com/intent/tweet?text=${text}`, "_blank");
+}
+
+function shareFacebook() {
+  const url = encodeURIComponent(window.location.href);
+  window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, "_blank");
+}
+
+function shareInstagram() {
+  copyShareText();
+  alert("Result copied! Open Instagram and paste it in your story 😊");
+}
+
+function copyShareText() {
+  navigator.clipboard.writeText(getShareText())
+    .then(() => alert("Copied to clipboard!"))
+    .catch(() => alert("Could not copy automatically."));
+}


### PR DESCRIPTION


📌 Description
Added a Share Result modal that allows users to share their cooked percentage through multiple platforms.
Improved share message formatting for proper hyperlink detection and replaced localhost link with production GitHub Pages URL.

---

## 🔗 Related Issue
Closes #1 

---

## 🛠 Changes Made

- Added Share Result modal UI

- Implemented WhatsApp, X (Twitter), and Facebook sharing

- Added Instagram fallback (copy to clipboard)

- Added Copy button for manual sharing

- Improved message formatting for clickable hyperlinks

- Replaced localhost URL with production GitHub Pages link


---

## 📷 Screenshots (if applicable)
<img width="1910" height="996" alt="image" src="https://github.com/user-attachments/assets/d4eca49f-5cd1-442e-8986-a4f5bed48d40" />


---

## ✅ Checklist
- [ ✅] I have tested my changes
- [✅ ] My code follows project guidelines
- [✅ ] I have linked the related issue
